### PR TITLE
clang-win-activation 22.1.2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -17,9 +17,6 @@ runtime_version:
  - 14.42.34433
  - 14.29.30133
 
-c_stdlib_version:   # [win]
-  - 2022.14         # [win]
-
 zip_keys:
  - - vcver
    - vsyear

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "21.1.8" %}
+{% set version = "22.1.2" %}
 
 {% if not vsyear %}
   {% set vsyear = "" %}


### PR DESCRIPTION
clang-win-activation 22.1.2

**Destination channel:** defaults

### Links

- [PKG-13446](https://anaconda.atlassian.net/browse/PKG-13446)
- [Upstream repository](https://github.com/llvm/llvm-project)
- [Upstream changelog/diff](https://github.com/llvm/llvm-project/compare/llvmorg-21.1.8...llvmorg-22.1.2)
- Relevant dependency PRs:
  - clangdev: AnacondaRecipes/clangdev-feedstock#23
  - llvmdev (provides llvm-tools): AnacondaRecipes/llvmdev-feedstock#36 
  - lld: AnacondaRecipes/lld-feedstock#14 
  - compiler-rt: AnacondaRecipes/compiler-rt-feedstock#11 

### Explanation of changes:

- Version bump 21.1.8 → 22.1.2.

[PKG-13446]: https://anaconda.atlassian.net/browse/PKG-13446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-12851]: https://anaconda.atlassian.net/browse/PKG-12851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ